### PR TITLE
Add message counter for one to one smoke tests

### DIFF
--- a/docker/docker-compose-grpc.yml
+++ b/docker/docker-compose-grpc.yml
@@ -64,3 +64,23 @@ services:
       federator-server:
         condition: service_started
     restart: on-failure
+
+  kafka-message-counter:
+    build:
+      context: kafka-message-counter
+      dockerfile: Dockerfile
+    container_name: kafka-message-counter
+    depends_on:
+      federator-client:
+        condition: service_started
+      kafka-topics-populator:
+        condition: service_completed_successfully
+    environment:
+      KAFKA_BROKER_SERVER: "kafka-target:19092"
+      TOPICS_TO_CHECK: "federated-FederatorServer1-knowledge"
+      EXPECTED_MESSAGE_COUNTS: "23"
+      DELAY_BEFORE_CONSUMING_DATA: "10"
+    networks:
+      - core
+    volumes:
+      - ../input:/usr/bin/input


### PR DESCRIPTION
## Sensitive Credential Checks

- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When attempting to document test steps for one server, one client connections in federator, we discovered that one to one smoke tests hadn't been properly implemented, so we decided to fix this.

## Description

- Added a `kafka-message-counter` container for checking the messages sent through a Kafka topic for the one server, one client docker compose setup

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

1. Go to the federator base directory
2. Run `docker compose -f docker/docker-compose-grpc.yml up -d` to spin up the containers
3. Run `docker logs kafka-message-counter --follow ` to get the message count from the logs
4. You should get this message in your terminal output:
```
✅ Topic 'federated-FederatorServer1-knowledge' has 23 messages (as expected).
```

## Screenshots (if appropriate):
N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

