### PR TITLE
feat(DPAV-1640): add support for Redis authentication

### DIFF
--- a/docker/docker-grpc-resources/client.properties
+++ b/docker/docker-grpc-resources/client.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer

--- a/docker/docker-grpc-resources/client.properties
+++ b/docker/docker-grpc-resources/client.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer
@@ -46,5 +46,8 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 # Location of the connections configuration json file in the docker container
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/multiple-clients-multiple-server/client1.properties
+++ b/docker/docker-grpc-resources/multiple-clients-multiple-server/client1.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer
@@ -44,6 +44,9 @@ kafka.consumerGroup=ndtp.dbt.gov.uk.1
 redis.host=redis
 ## Default redis.port is 6379
 redis.port=6379
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/multiple-clients-multiple-server/client1.properties
+++ b/docker/docker-grpc-resources/multiple-clients-multiple-server/client1.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer

--- a/docker/docker-grpc-resources/multiple-clients-multiple-server/client2.properties
+++ b/docker/docker-grpc-resources/multiple-clients-multiple-server/client2.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer
@@ -46,4 +46,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/multiple-clients-multiple-server/client2.properties
+++ b/docker/docker-grpc-resources/multiple-clients-multiple-server/client2.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer

--- a/docker/docker-grpc-resources/multiple-clients-single-server/client1.properties
+++ b/docker/docker-grpc-resources/multiple-clients-single-server/client1.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer
@@ -46,4 +46,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/multiple-clients-single-server/client1.properties
+++ b/docker/docker-grpc-resources/multiple-clients-single-server/client1.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer

--- a/docker/docker-grpc-resources/multiple-clients-single-server/client2.properties
+++ b/docker/docker-grpc-resources/multiple-clients-single-server/client2.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer
@@ -46,4 +46,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/multiple-clients-single-server/client2.properties
+++ b/docker/docker-grpc-resources/multiple-clients-single-server/client2.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer

--- a/docker/docker-grpc-resources/performance-tests/single-client-ten-servers/client1.properties
+++ b/docker/docker-grpc-resources/performance-tests/single-client-ten-servers/client1.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/docker-grpc-resources/performance-tests/single-client-ten-servers/client1.properties
+++ b/docker/docker-grpc-resources/performance-tests/single-client-ten-servers/client1.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,4 +27,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client1.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client1.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client1.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client1.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,4 +27,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client10.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client10.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client10.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client10.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,4 +27,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client2.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client2.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client2.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client2.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,4 +27,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client3.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client3.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client3.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client3.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,4 +27,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client4.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client4.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client4.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client4.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,4 +27,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client5.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client5.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client5.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client5.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,4 +27,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client6.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client6.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client6.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client6.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,4 +27,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client7.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client7.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client7.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client7.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,4 +27,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client8.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client8.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client8.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client8.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,4 +27,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client9.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client9.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client9.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client9.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,4 +27,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -22,6 +22,8 @@ This is defined in a properties file (`client.properties`) file whose location i
 | `redis.host`                               | the host for the redis cache                                                                                                                                                                                                          |
 | `redis.port`                               | the port for the redis cache                                                                                                                                                                                                          |
 | `redis.tls.enabled`                        | a flag to indicate if TLS is enabled for the redis cache                                                                                                                                                                              |
+| `redis.username`                           | the username for authenticating connections when redis Access Control List is being used. This can be left empty if either authentication is not required, or if redis only has `requirepass` enabled
+| `redis.password`                           | the password to be used for authenticating connections to redis. If either authentication is not required this can be left blank
 | `connections.configuration`                | the connection configuration for the client (see `connection-configuration.json` below) - Typically this will be `/config/connection-configuration.json` as in docker we will mount different volumes/files for each client container |
 
 #### Connection Configuration JSON

--- a/docs/new-client-server.md
+++ b/docs/new-client-server.md
@@ -172,6 +172,9 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=/config/connection-configuration.json
 ````
 

--- a/pom.xml
+++ b/pom.xml
@@ -359,11 +359,11 @@
         </configuration>
         <executions>
           <execution>
-            <phase>generate-sources</phase>
             <goals>
               <goal>compile</goal>
               <goal>compile-custom</goal>
             </goals>
+            <phase>generate-sources</phase>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -359,6 +359,7 @@
         </configuration>
         <executions>
           <execution>
+            <phase>generate-sources</phase>
             <goals>
               <goal>compile</goal>
               <goal>compile-custom</goal>

--- a/src/configs/client.properties
+++ b/src/configs/client.properties
@@ -40,12 +40,17 @@ kafka.bootstrapServers=localhost:29093
 ## kafka.topic.prefix default is empty string
 kafka.topic.prefix=federated
 kafka.consumerGroup=ndtp.dbt.gov.uk
+
 ## Default redis.host is localhost
 redis.host=localhost
 ## Default redis.port is 6379
 redis.port=6380
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
+
 ## If client.tlsEnabled is set to true then you need to set the file path for CA cert and P12 file
 client.p12Password=
 client.p12FilePath=

--- a/src/configs/multi-server-client.properties
+++ b/src/configs/multi-server-client.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/configs/multi-server-client.properties
+++ b/src/configs/multi-server-client.properties
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,4 +23,7 @@ kafka.consumerGroup=ndtp.dbt.gov.uk
 redis.host=localhost
 redis.port=6380
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=src/configs/multi-server-connection-configuration.json

--- a/src/configs/multiple-clients-client2.properties
+++ b/src/configs/multiple-clients-client2.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer
@@ -46,4 +46,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=src/configs/connection-configuration.json

--- a/src/configs/multiple-clients-client2.properties
+++ b/src/configs/multiple-clients-client2.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer

--- a/src/main/java/uk/gov/dbt/ndtp/federator/utils/RedisUtil.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/utils/RedisUtil.java
@@ -28,9 +28,9 @@ package uk.gov.dbt.ndtp.federator.utils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import redis.clients.jedis.JedisPooled;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisPooled;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
 /**
@@ -78,11 +78,12 @@ public class RedisUtil {
             String username = PropertyUtil.getPropertyValue(REDIS_USERNAME, "");
             String password = PropertyUtil.getPropertyValue(REDIS_PASSWORD, "");
 
-            // Note redis authentication can be configured to use just a password, or both username and password, hence only presence of a password is tested
+            // Note redis authentication can be configured to use just a password, or both username and password, hence
+            // only presence of a password is tested
             // to determine whether authentication credentials should be used.
             if (!password.isBlank()) {
-                LOGGER.info("Using authentication with Redis");  
-                instance = new RedisUtil(host, port, isTLSEnabled, username, password);         
+                LOGGER.info("Using authentication with Redis");
+                instance = new RedisUtil(host, port, isTLSEnabled, username, password);
             } else {
                 instance = new RedisUtil(host, port, isTLSEnabled);
             }
@@ -145,17 +146,19 @@ public class RedisUtil {
      * @param username redis username.
      * @param password redis password.
      */
-    private static JedisPooled buildAuthenticatedRedisConnection(String host, int port, boolean isTLSEnabled, String username, String password) {
+    private static JedisPooled buildAuthenticatedRedisConnection(
+            String host, int port, boolean isTLSEnabled, String username, String password) {
 
-        // Create the JedisPooled instance with authentication. A Jedis client config builder is used here in absence of a native Jedis constructor
+        // Create the JedisPooled instance with authentication. A Jedis client config builder is used here in absence of
+        // a native Jedis constructor
         // that supports both TLS and username/password authentication.
         DefaultJedisClientConfig.Builder b = DefaultJedisClientConfig.builder().ssl(isTLSEnabled);
 
         if (!username.isBlank()) {
             b.user(username);
-        };
+        }
 
-        if (!password.isBlank()) { 
+        if (!password.isBlank()) {
             b.password(password);
         }
 

--- a/src/test/java/uk/gov/dbt/ndtp/federator/utils/RedisUtilTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/utils/RedisUtilTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-
 import redis.clients.jedis.JedisPooled;
 
 @Testcontainers
@@ -148,8 +147,8 @@ class RedisUtilTest {
             TestPropertyUtil.clearProperties();
 
             // create ACL user
-            try (redis.clients.jedis.Jedis admin = new redis.clients.jedis.Jedis(redis.getRedisHost(),
-                    redis.getRedisPort())) {
+            try (redis.clients.jedis.Jedis admin =
+                    new redis.clients.jedis.Jedis(redis.getRedisHost(), redis.getRedisPort())) {
                 admin.aclSetUser(USER, "on", ">" + PASS, "allcommands", "allkeys");
             }
 
@@ -163,7 +162,8 @@ class RedisUtilTest {
                             redis.tls.enabled=false
                             redis.username=%s
                             redis.password=%s
-                            """.formatted(redis.getRedisHost(), redis.getRedisPort(), USER, PASS));
+                            """
+                            .formatted(redis.getRedisHost(), redis.getRedisPort(), USER, PASS));
             File tmpProperties = tmp.toFile();
             tmpProperties.deleteOnExit();
             PropertyUtil.init(tmpProperties);
@@ -177,8 +177,8 @@ class RedisUtilTest {
         @AfterAll
         static void afterAll() throws Exception {
             // clean up ACL user
-            try (redis.clients.jedis.Jedis admin = new redis.clients.jedis.Jedis(redis.getRedisHost(),
-                    redis.getRedisPort())) {
+            try (redis.clients.jedis.Jedis admin =
+                    new redis.clients.jedis.Jedis(redis.getRedisHost(), redis.getRedisPort())) {
                 admin.aclDelUser(USER);
             }
             TestPropertyUtil.clearProperties();

--- a/src/test/resources/client.properties
+++ b/src/test/resources/client.properties
@@ -25,4 +25,7 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
 connections.configuration=src/test/resources/connection-configuration.json


### PR DESCRIPTION
## Sensitive Credential Checks

- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
Adds support for Redis authentication both through use of Redis ACLs and `requirepass` configuration.

## Description
Adds new configuration options (with documentation updates) that allow redis authentication parameters to be passed. If no authentication is required, both username and password can be left blank. If `requirepass` only is configured, just the `redis.password` field needs to be set. If Redis ACLs are in use, both username and password should be populated. Documentation in [client-configuration.md](./docs/client-configuration.md) has been updated to reflect the newly accepted configuration options. 

## How Has This Been Tested?
Tested locally across all three scenarios (no auth, password-only and username/password). The docker-compose configurations below can be used to adjust redis in locally running environments.

Password only authentication:
```
  redis:
    image: redis
    container_name: redis
    command:
      - sh
      - -c
      - |
        exec redis-server --appendonly no \
          --user default on ">$$REDIS_PASSWORD" allkeys allcommands
    environment:
      REDIS_PASSWORD: example
    ports:
      - "6380:6379"
    healthcheck:
      test: ["CMD-SHELL","redis-cli -h 127.0.0.1 -p 6379 -a $${REDIS_PASSWORD} ping | grep PONG"]
      interval: 1s
      timeout: 60s
      retries: 60
    networks:
      - core
    restart: on-failure
```

Username and password authentication:
```
  redis:
    image: redis
    container_name: redis
    command:
      - sh
      - -c
      - |
        exec redis-server --appendonly no \
          --user default off \
          --user "$$REDIS_USERNAME" on ">$$REDIS_PASSWORD" allkeys allcommands
    environment:
      REDIS_USERNAME: example_user
      REDIS_PASSWORD: example
    ports:
      - "6380:6379"
    healthcheck:
      test: ["CMD-SHELL","redis-cli -u redis://$${REDIS_USERNAME}:$${REDIS_PASSWORD}@127.0.0.1:6379 ping | grep PONG"]
      interval: 1s
      timeout: 60s
      retries: 60
    networks:
      - core
    restart: on-failure
```

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [X] Includes link to an issue (if apply)
- [X] I have added tests to cover my changes.