### PR TITLE
feat(DPAV-1644): add support for JWT access token caching using Redis

### DIFF
--- a/docker/docker-grpc-resources/client.properties
+++ b/docker/docker-grpc-resources/client.properties
@@ -49,5 +49,7 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 # Location of the connections configuration json file in the docker container
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/multiple-clients-multiple-server/client1.properties
+++ b/docker/docker-grpc-resources/multiple-clients-multiple-server/client1.properties
@@ -49,4 +49,6 @@ redis.username=
 redis.password=
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/multiple-clients-multiple-server/client2.properties
+++ b/docker/docker-grpc-resources/multiple-clients-multiple-server/client2.properties
@@ -49,4 +49,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/multiple-clients-single-server/client1.properties
+++ b/docker/docker-grpc-resources/multiple-clients-single-server/client1.properties
@@ -49,4 +49,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/multiple-clients-single-server/client2.properties
+++ b/docker/docker-grpc-resources/multiple-clients-single-server/client2.properties
@@ -49,4 +49,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/single-client-ten-servers/client1.properties
+++ b/docker/docker-grpc-resources/performance-tests/single-client-ten-servers/client1.properties
@@ -30,4 +30,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client1.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client1.properties
@@ -30,4 +30,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client10.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client10.properties
@@ -30,4 +30,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client2.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client2.properties
@@ -30,4 +30,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client3.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client3.properties
@@ -30,4 +30,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client4.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client4.properties
@@ -30,4 +30,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client5.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client5.properties
@@ -30,4 +30,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client6.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client6.properties
@@ -30,4 +30,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client7.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client7.properties
@@ -30,4 +30,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client8.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client8.properties
@@ -30,4 +30,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client9.properties
+++ b/docker/docker-grpc-resources/performance-tests/ten-clients-single-server/client9.properties
@@ -30,4 +30,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -24,6 +24,7 @@ This is defined in a properties file (`client.properties`) file whose location i
 | `redis.tls.enabled`                        | a flag to indicate if TLS is enabled for the redis cache                                                                                                                                                                              |
 | `redis.username`                           | the username for authenticating connections when redis Access Control List is being used. This can be left empty if either authentication is not required, or if redis only has `requirepass` enabled
 | `redis.password`                           | the password to be used for authenticating connections to redis. If either authentication is not required this can be left blank
+| `redis.aes.key`                            | if set, this will be used to encrypt access tokens (using AES) stored in Redis to avoid multiple calls by federator clients. The value must be Base64 and decode to 16, 24, or 32 bytes.
 | `connections.configuration`                | the connection configuration for the client (see `connection-configuration.json` below) - Typically this will be `/config/connection-configuration.json` as in docker we will mount different volumes/files for each client container |
 
 #### Connection Configuration JSON

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -24,7 +24,7 @@ This is defined in a properties file (`client.properties`) file whose location i
 | `redis.tls.enabled`                        | a flag to indicate if TLS is enabled for the redis cache                                                                                                                                                                              |
 | `redis.username`                           | the username for authenticating connections when redis Access Control List is being used. This can be left empty if either authentication is not required, or if redis only has `requirepass` enabled
 | `redis.password`                           | the password to be used for authenticating connections to redis. If either authentication is not required this can be left blank
-| `redis.aes.key`                            | if set, this will be used to encrypt access tokens (using AES) stored in Redis to avoid multiple calls by federator clients. The value must be Base64 and decode to 16, 24, or 32 bytes.
+| `redis.aes.key`                            | if set, this will be used to encrypt values stored in Redis. The value must be Base64 and decode to 16, 24, or 32 bytes.
 | `connections.configuration`                | the connection configuration for the client (see `connection-configuration.json` below) - Typically this will be `/config/connection-configuration.json` as in docker we will mount different volumes/files for each client container |
 
 #### Connection Configuration JSON

--- a/docs/new-client-server.md
+++ b/docs/new-client-server.md
@@ -175,6 +175,8 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=/config/connection-configuration.json
 ````
 

--- a/src/configs/client.properties
+++ b/src/configs/client.properties
@@ -51,6 +51,9 @@ redis.tls.enabled=false
 redis.username=
 redis.password=
 
+# If you want to encrypt values stored in Redis then set this property to the AES key (Base64 encoded) to use for encryption/decryption.
+redis.aes.key=
+
 ## If client.tlsEnabled is set to true then you need to set the file path for CA cert and P12 file
 client.p12Password=
 client.p12FilePath=

--- a/src/configs/client.properties
+++ b/src/configs/client.properties
@@ -51,7 +51,7 @@ redis.tls.enabled=false
 redis.username=
 redis.password=
 
-# If you want to encrypt values stored in Redis then set this property to the AES key (Base64 encoded) to use for encryption/decryption.
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
 redis.aes.key=
 
 ## If client.tlsEnabled is set to true then you need to set the file path for CA cert and P12 file

--- a/src/configs/common-configuration.properties
+++ b/src/configs/common-configuration.properties
@@ -13,6 +13,9 @@ idp.jwks.url=${IDP_JWKS_URL}
 # Token endpoint URL of the IDP (used to fetch OAuth2 tokens)
 idp.token.url=${IDP_TOKEN_URL}
 
+# Backoff time in milliseconds before retrying a failed token request (default: 1000 ms)
+idp.token.backoff=1000
+
 # OAuth2 client ID (registered with the IDP)
 idp.client.id=${IDP_CLIENT_ID}
 
@@ -27,7 +30,6 @@ idp.truststore.path=${IDP_TRUSTSTORE_PATH}
 
 # Password for the truststore
 idp.truststore.password=${IDP_TRUSTSTORE_PASSWORD}
-
 
 
 

--- a/src/configs/multi-server-client.properties
+++ b/src/configs/multi-server-client.properties
@@ -26,4 +26,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=src/configs/multi-server-connection-configuration.json

--- a/src/configs/multiple-clients-client1.properties
+++ b/src/configs/multiple-clients-client1.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# � Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer

--- a/src/configs/multiple-clients-client1.properties
+++ b/src/configs/multiple-clients-client1.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Modifications made by the National Digital Twin Programme (NDTP)
-# © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+# ï¿½ Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 # and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 kafka.sender.defaultKeySerializerClass=org.apache.kafka.common.serialization.BytesSerializer
@@ -46,4 +46,9 @@ redis.host=redis
 redis.port=6379
 ## Default redis.tls.enabled empty value "" = false, missing property entry = true
 redis.tls.enabled=false
+# If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
+redis.username=
+redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=src/configs/connection-configuration.json

--- a/src/configs/multiple-clients-client2.properties
+++ b/src/configs/multiple-clients-client2.properties
@@ -49,4 +49,6 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=src/configs/connection-configuration.json

--- a/src/main/java/uk/gov/dbt/ndtp/federator/exceptions/AesCryptographicOperationException.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/exceptions/AesCryptographicOperationException.java
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Originally developed by Telicent Ltd.; subsequently adapted, enhanced, and maintained by the National Digital Twin
+// Programme.
+
+package uk.gov.dbt.ndtp.federator.exceptions;
+
+/**
+ * Exception for AES cryptographic operation failures
+ */
+public class AesCryptographicOperationException extends RuntimeException {
+
+    public AesCryptographicOperationException(String message) {
+        super(message);
+    }
+
+    public AesCryptographicOperationException(String message, Throwable e) {
+        super(message, e);
+    }
+}

--- a/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenService.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenService.java
@@ -21,9 +21,16 @@ public interface IdpTokenService {
     String CONTENT_TYPE_FORM_URLENCODED = "application/x-www-form-urlencoded";
 
     /**
-     * Fetch an access token from the IDP.
+     * Fetch an access token from the default management node IDP.
+     * @param managementNodeId The management node ID for which the token is being fetched.
      */
     String fetchToken();
+
+    /**
+     * Fetch an access token from the IDP associated with a specific identifier..
+     * @param managementNodeId The management node ID for which the token is being fetched.
+     */
+    String fetchToken(String managementNodeId);
 
     /**
      * Verify an access token against the IDP's JWKS.

--- a/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenService.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenService.java
@@ -22,7 +22,6 @@ public interface IdpTokenService {
 
     /**
      * Fetch an access token from the default management node IDP.
-     * @param managementNodeId The management node ID for which the token is being fetched.
      */
     String fetchToken();
 

--- a/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceImpl.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceImpl.java
@@ -36,7 +36,7 @@ public class IdpTokenServiceImpl implements IdpTokenService {
 
     private static final String COMMON_CONFIG_PROPERTIES = "common.configuration";
     private static final String MANAGEMENT_NODE_DEFAULT_ID = "default";
-    private static final long TOKEN_REQUEST_BACKOFF = 1000; // milliseconds
+    private final long tokenRequestBackoff; // milliseconds
     private final String idpJwksUrl;
     private final String idpTokenUrl;
     private final String idpClientId;
@@ -48,6 +48,7 @@ public class IdpTokenServiceImpl implements IdpTokenService {
         this.idpJwksUrl = properties.getProperty("idp.jwks.url");
         this.idpTokenUrl = properties.getProperty("idp.token.url");
         this.idpClientId = properties.getProperty("idp.client.id");
+        this.tokenRequestBackoff = Long.parseLong(properties.getProperty("idp.token.backoff", "1000"));
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
     }
@@ -90,7 +91,7 @@ public class IdpTokenServiceImpl implements IdpTokenService {
                         "Initial token fetch failed for management node {}. HTTP {}. Retrying once.",
                         managementNodeId,
                         response.statusCode());
-                Thread.sleep(TOKEN_REQUEST_BACKOFF);
+                Thread.sleep(tokenRequestBackoff);
                 response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             }
 

--- a/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceImpl.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceImpl.java
@@ -75,7 +75,8 @@ public class IdpTokenServiceImpl implements IdpTokenService {
             log.debug("No cached token in Redis for management node {}, fetching from IDP", managementNodeId);
 
             String body =
-                    GRANT_TYPE + EQUALS_SIGN + CLIENT_CREDENTIALS + AMPERSAND + CLIENT_ID + EQUALS_SIGN + idpClientId;
+                    GRANT_TYPE + EQUALS_SIGN + CLIENT_CREDENTIALS + AMPERSAND + CLIENT_ID + EQUALS_SIGN + idpClientId
+                    + "&client_secret=roZDoPEnk2TtV8kY464f8UfLA0Vi8uB5";
 
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(idpTokenUrl))

--- a/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceImpl.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceImpl.java
@@ -36,6 +36,7 @@ public class IdpTokenServiceImpl implements IdpTokenService {
 
     private static final String COMMON_CONFIG_PROPERTIES = "common.configuration";
     private static final String MANAGEMENT_NODE_DEFAULT_ID = "default";
+    private static final long TOKEN_REQUEST_BACKOFF = 1000; // milliseconds
     private final String idpJwksUrl;
     private final String idpTokenUrl;
     private final String idpClientId;
@@ -73,8 +74,8 @@ public class IdpTokenServiceImpl implements IdpTokenService {
 
             log.debug("No cached token in Redis for management node {}, fetching from IDP", managementNodeId);
 
-            String body = GRANT_TYPE + EQUALS_SIGN + CLIENT_CREDENTIALS
-                    + AMPERSAND + CLIENT_ID + EQUALS_SIGN + idpClientId;
+            String body =
+                    GRANT_TYPE + EQUALS_SIGN + CLIENT_CREDENTIALS + AMPERSAND + CLIENT_ID + EQUALS_SIGN + idpClientId;
 
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(idpTokenUrl))
@@ -86,10 +87,10 @@ public class IdpTokenServiceImpl implements IdpTokenService {
 
             if (response.statusCode() != 200) {
                 log.info(
-                        "Token fetch failed for management node {}. HTTP {}. Retrying once.",
+                        "Initial token fetch failed for management node {}. HTTP {}. Retrying once.",
                         managementNodeId,
                         response.statusCode());
-                Thread.sleep(1000);
+                Thread.sleep(TOKEN_REQUEST_BACKOFF);
                 response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             }
 

--- a/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceImpl.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceImpl.java
@@ -111,7 +111,7 @@ public class IdpTokenServiceImpl implements IdpTokenService {
             long expiresIn = ((Number) json.get("expires_in")).longValue(); // seconds
 
             log.info("Access token fetched for management node {}, persisting to Redis", managementNodeId);
-            RedisUtil.getInstance().setValue(redisKey, accessToken, true, expiresIn);
+            RedisUtil.getInstance().setValue(redisKey, accessToken, expiresIn);
 
             return accessToken;
 

--- a/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceImpl.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceImpl.java
@@ -75,8 +75,7 @@ public class IdpTokenServiceImpl implements IdpTokenService {
             log.debug("No cached token in Redis for management node {}, fetching from IDP", managementNodeId);
 
             String body =
-                    GRANT_TYPE + EQUALS_SIGN + CLIENT_CREDENTIALS + AMPERSAND + CLIENT_ID + EQUALS_SIGN + idpClientId
-                    + "&client_secret=roZDoPEnk2TtV8kY464f8UfLA0Vi8uB5";
+                    GRANT_TYPE + EQUALS_SIGN + CLIENT_CREDENTIALS + AMPERSAND + CLIENT_ID + EQUALS_SIGN + idpClientId;
 
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(idpTokenUrl))

--- a/src/main/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtil.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtil.java
@@ -11,7 +11,6 @@ import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-
 import uk.gov.dbt.ndtp.federator.exceptions.AesCryptographicOperationException;
 
 /**

--- a/src/main/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtil.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtil.java
@@ -12,6 +12,8 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import uk.gov.dbt.ndtp.federator.exceptions.AesCryptographicOperationException;
+
 /**
  * Utility class for AES-GCM encryption and decryption with Base64-encoded keys and data.
  * This class provides methods to encrypt and decrypt UTF-8 text using AES in GCM mode with no padding.
@@ -87,7 +89,7 @@ public class AesCryptoUtil {
      * @param plainText UTF-8 text
      * @param key       AES secret key
      * @return Base64-encoded {@code IV || ciphertext || tag}
-     * @throws IllegalStateException if encryption fails
+     * @throws AesCryptographicOperationException if encryption fails
      */
     private static String encryptToBase64(String plainText, SecretKey key) {
         try {
@@ -103,7 +105,7 @@ public class AesCryptoUtil {
             System.arraycopy(ct, 0, out, iv.length, ct.length);
             return Base64.getEncoder().encodeToString(out);
         } catch (Exception e) {
-            throw new IllegalStateException("encryption failed", e);
+            throw new AesCryptographicOperationException("encryption failed", e);
         }
     }
 
@@ -114,7 +116,7 @@ public class AesCryptoUtil {
      * @param key        AES secret key
      * @return plaintext as UTF-8
      * @throws IllegalArgumentException if the input is too short
-     * @throws IllegalStateException if decryption or authentication fails
+     * @throws AesCryptographicOperationException if decryption fails
      */
     private static String decryptFromBase64(String base64Data, SecretKey key) {
         try {
@@ -132,7 +134,7 @@ public class AesCryptoUtil {
             byte[] pt = cipher.doFinal(ct);
             return new String(pt, StandardCharsets.UTF_8);
         } catch (Exception e) {
-            throw new IllegalStateException("decryption failed", e);
+            throw new AesCryptographicOperationException("decryption failed", e);
         }
     }
 }

--- a/src/main/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtil.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtil.java
@@ -12,13 +12,21 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-public class AesCryptoUtils {
+/**
+ * Utility class for AES-GCM encryption and decryption with Base64-encoded keys and data.
+ * This class provides methods to encrypt and decrypt UTF-8 text using AES in GCM mode with no padding.
+ * The AES key is provided as a Base64-encoded string, and the encrypted output is also Base64-encoded.
+ * <p>
+ **/
+public class AesCryptoUtil {
 
     private static final String AES = "AES";
     private static final String TRANSFORMATION = "AES/GCM/NoPadding";
     private static final int GCM_TAG_BITS = 128;
     private static final int IV_LEN = 12;
     private static final SecureRandom RNG = new SecureRandom();
+
+    private AesCryptoUtil() {}
 
     /**
      * Encrypts UTF-8 text with AES-GCM using a Base64 key.
@@ -66,9 +74,9 @@ public class AesCryptoUtils {
             throw new IllegalArgumentException("key is blank");
         }
         byte[] keyBytes = Base64.getDecoder().decode(base64Key);
-        int n = keyBytes.length;
-        if (n != 16 && n != 24 && n != 32) {
-            throw new IllegalArgumentException("AES key must be 16, 24, or 32 bytes");
+        int decodedKeyLength = keyBytes.length;
+        if (decodedKeyLength != 16 && decodedKeyLength != 24 && decodedKeyLength != 32) {
+            throw new IllegalArgumentException("AES key must be 16, 24, or 32 bytes. Got " + decodedKeyLength);
         }
         return new SecretKeySpec(keyBytes, AES);
     }
@@ -95,7 +103,7 @@ public class AesCryptoUtils {
             System.arraycopy(ct, 0, out, iv.length, ct.length);
             return Base64.getEncoder().encodeToString(out);
         } catch (Exception e) {
-            throw new IllegalStateException("encrypt failed", e);
+            throw new IllegalStateException("encryption failed", e);
         }
     }
 
@@ -124,7 +132,7 @@ public class AesCryptoUtils {
             byte[] pt = cipher.doFinal(ct);
             return new String(pt, StandardCharsets.UTF_8);
         } catch (Exception e) {
-            throw new IllegalStateException("decrypt failed", e);
+            throw new IllegalStateException("decryption failed", e);
         }
     }
 }

--- a/src/main/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtils.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtils.java
@@ -55,22 +55,6 @@ public class AesCryptoUtils {
     }
 
     /**
-     * Generates a random AES key and returns it as Base64.
-     *
-     * @param bits key size in bits. Must be 128, 192, or 256
-     * @return Base64-encoded key
-     * @throws IllegalArgumentException if {@code bits} is not one of 128, 192, 256
-     */
-    public static String generateRandomKeyBase64(int bits) {
-        if (bits != 128 && bits != 192 && bits != 256) {
-            throw new IllegalArgumentException("bits must be 128, 192, or 256");
-        }
-        byte[] k = new byte[bits / 8];
-        RNG.nextBytes(k);
-        return Base64.getEncoder().encodeToString(k);
-    }
-
-    /**
      * Builds a {@link SecretKey} from a Base64 string.
      *
      * @param base64Key Base64-encoded AES key

--- a/src/main/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtils.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtils.java
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Originally developed by Telicent Ltd.; subsequently adapted, enhanced, and maintained by the National Digital Twin
+// Programme.
+
+package uk.gov.dbt.ndtp.federator.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class AesCryptoUtils {
+
+    private static final String AES = "AES";
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int GCM_TAG_BITS = 128;
+    private static final int IV_LEN = 12;
+    private static final SecureRandom RNG = new SecureRandom();
+
+    /**
+     * Encrypts UTF-8 text with AES-GCM using a Base64 key.
+     * <p>
+     * Output is a Base64 string of {@code IV || ciphertext || tag}.
+     * </p>
+     *
+     * @param plainText the UTF-8 text to encrypt
+     * @param base64Key the AES key in Base64. Must decode to 16, 24, or 32 bytes
+     * @return Base64 of {@code IV || ciphertext || tag}
+     * @throws IllegalArgumentException if the key is blank or has an invalid length
+     * @throws IllegalStateException if the cryptographic operation fails
+     */
+    public static String encrypt(String plainText, String base64Key) {
+        SecretKey key = keyFromBase64(base64Key);
+        return encryptToBase64(plainText, key);
+    }
+
+    /**
+     * Decrypts a Base64 string produced by {@link #encrypt(String, String)}.
+     * <p>
+     * Input must be Base64 of {@code IV || ciphertext || tag}.
+     * </p>
+     *
+     * @param base64CipherText Base64 of {@code IV || ciphertext || tag}
+     * @param base64Key        the AES key in Base64. Must decode to 16, 24, or 32 bytes
+     * @return the decrypted UTF-8 text
+     * @throws IllegalArgumentException if input is too short or the key is invalid
+     * @throws IllegalStateException if decryption or authentication fails
+     */
+    public static String decrypt(String base64CipherText, String base64Key) {
+        SecretKey key = keyFromBase64(base64Key);
+        return decryptFromBase64(base64CipherText, key);
+    }
+
+    /**
+     * Generates a random AES key and returns it as Base64.
+     *
+     * @param bits key size in bits. Must be 128, 192, or 256
+     * @return Base64-encoded key
+     * @throws IllegalArgumentException if {@code bits} is not one of 128, 192, 256
+     */
+    public static String generateRandomKeyBase64(int bits) {
+        if (bits != 128 && bits != 192 && bits != 256) {
+            throw new IllegalArgumentException("bits must be 128, 192, or 256");
+        }
+        byte[] k = new byte[bits / 8];
+        RNG.nextBytes(k);
+        return Base64.getEncoder().encodeToString(k);
+    }
+
+    /**
+     * Builds a {@link SecretKey} from a Base64 string.
+     *
+     * @param base64Key Base64-encoded AES key
+     * @return the SecretKey instance
+     * @throws IllegalArgumentException if the key is blank or not 16, 24, or 32 bytes after decoding
+     */
+    private static SecretKey keyFromBase64(String base64Key) {
+        if (base64Key == null || base64Key.isBlank()) {
+            throw new IllegalArgumentException("key is blank");
+        }
+        byte[] keyBytes = Base64.getDecoder().decode(base64Key);
+        int n = keyBytes.length;
+        if (n != 16 && n != 24 && n != 32) {
+            throw new IllegalArgumentException("AES key must be 16, 24, or 32 bytes");
+        }
+        return new SecretKeySpec(keyBytes, AES);
+    }
+
+    /**
+     * Encrypts text and returns Base64 of {@code IV || ciphertext || tag}.
+     *
+     * @param plainText UTF-8 text
+     * @param key       AES secret key
+     * @return Base64-encoded {@code IV || ciphertext || tag}
+     * @throws IllegalStateException if encryption fails
+     */
+    private static String encryptToBase64(String plainText, SecretKey key) {
+        try {
+            byte[] iv = new byte[IV_LEN];
+            RNG.nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_BITS, iv));
+            byte[] ct = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+
+            byte[] out = new byte[iv.length + ct.length];
+            System.arraycopy(iv, 0, out, 0, iv.length);
+            System.arraycopy(ct, 0, out, iv.length, ct.length);
+            return Base64.getEncoder().encodeToString(out);
+        } catch (Exception e) {
+            throw new IllegalStateException("encrypt failed", e);
+        }
+    }
+
+    /**
+     * Decrypts Base64 of {@code IV || ciphertext || tag} and returns UTF-8 text.
+     *
+     * @param base64Data Base64-encoded {@code IV || ciphertext || tag}
+     * @param key        AES secret key
+     * @return plaintext as UTF-8
+     * @throws IllegalArgumentException if the input is too short
+     * @throws IllegalStateException if decryption or authentication fails
+     */
+    private static String decryptFromBase64(String base64Data, SecretKey key) {
+        try {
+            byte[] all = Base64.getDecoder().decode(base64Data);
+            if (all.length < IV_LEN + 1) {
+                throw new IllegalArgumentException("ciphertext too short");
+            }
+            byte[] iv = new byte[IV_LEN];
+            System.arraycopy(all, 0, iv, 0, IV_LEN);
+            byte[] ct = new byte[all.length - IV_LEN];
+            System.arraycopy(all, IV_LEN, ct, 0, ct.length);
+
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_BITS, iv));
+            byte[] pt = cipher.doFinal(ct);
+            return new String(pt, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalStateException("decrypt failed", e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/dbt/ndtp/federator/utils/RedisUtil.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/utils/RedisUtil.java
@@ -237,7 +237,8 @@ public class RedisUtil {
     public <T> boolean setValue(String key, T value, boolean encrypt, Long ttlSeconds) {
         try {
             String json = MAPPER.writeValueAsString(value);
-            String toWrite = encrypt && redisAesKeyValueIsSet() ? AesCryptoUtils.encrypt(json, REDIS_AES_KEY_VALUE) : json;
+            String toWrite =
+                    encrypt && redisAesKeyValueIsSet() ? AesCryptoUtils.encrypt(json, REDIS_AES_KEY_VALUE) : json;
 
             if (ttlSeconds != null && ttlSeconds > 0) {
                 LOGGER.debug("Persisting key in redis {} (encrypted={}, ttlSeconds={})", key, encrypt, ttlSeconds);
@@ -266,7 +267,8 @@ public class RedisUtil {
         try {
             String stored = jedisPooled.get(key);
             if (stored == null) return null;
-            String json = encrypted && redisAesKeyValueIsSet() ? AesCryptoUtils.decrypt(stored, REDIS_AES_KEY_VALUE) : stored;
+            String json =
+                    encrypted && redisAesKeyValueIsSet() ? AesCryptoUtils.decrypt(stored, REDIS_AES_KEY_VALUE) : stored;
             return MAPPER.readValue(json, type);
         } catch (Exception e) {
             throw new RuntimeException("Failed to get value from Redis for key " + key, e);

--- a/src/test/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtilsTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtilsTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
 
+import uk.gov.dbt.ndtp.federator.exceptions.AesCryptographicOperationException;
+
 class AesCryptoUtilsTest {
 
     // 16, 24, 32 bytes
@@ -61,7 +63,7 @@ class AesCryptoUtilsTest {
     void decrypt_withWrongKey_fails() {
         String pt = "secret";
         String ct = AesCryptoUtil.encrypt(pt, KEY_128);
-        assertThrows(IllegalStateException.class, () -> AesCryptoUtil.decrypt(ct, KEY_256));
+        assertThrows(AesCryptographicOperationException.class, () -> AesCryptoUtil.decrypt(ct, KEY_256));
     }
 
     @Test
@@ -80,13 +82,13 @@ class AesCryptoUtilsTest {
     void decrypt_shortCiphertext_fails() {
         // Base64 of 2 bytes, shorter than IV
         String shortCt = "AA==";
-        assertThrows(IllegalStateException.class, () -> AesCryptoUtil.decrypt(shortCt, KEY_128));
+        assertThrows(AesCryptographicOperationException.class, () -> AesCryptoUtil.decrypt(shortCt, KEY_128));
     }
 
     @Test
     void decrypt_badBase64_fails() {
         String notB64 = "%%%not-base64%%%";
-        assertThrows(IllegalStateException.class, () -> AesCryptoUtil.decrypt(notB64, KEY_128));
+        assertThrows(AesCryptographicOperationException.class, () -> AesCryptoUtil.decrypt(notB64, KEY_128));
     }
 
     @Test
@@ -96,6 +98,6 @@ class AesCryptoUtilsTest {
         byte[] bytes = Base64.getDecoder().decode(ct);
         bytes[bytes.length - 1] ^= 0x01; // flip last bit
         String tampered = Base64.getEncoder().encodeToString(bytes);
-        assertThrows(IllegalStateException.class, () -> AesCryptoUtil.decrypt(tampered, KEY_256));
+        assertThrows(AesCryptographicOperationException.class, () -> AesCryptoUtil.decrypt(tampered, KEY_256));
     }
 }

--- a/src/test/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtilsTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtilsTest.java
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Originally developed by Telicent Ltd.; subsequently adapted, enhanced, and maintained by the National Digital Twin
+// Programme.
+
+package uk.gov.dbt.ndtp.federator.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+class AesCryptoUtilsTest {
+
+    // 16, 24, 32 bytes
+    private static final String KEY_128 = "ET3igtDKRGp3+wrPhaSnXg==";
+    private static final String KEY_192 = "IgMvqWr9/aKEOHpx1/p+0JmISgbubU+I";
+    private static final String KEY_256 = "Bg7HhP2hl/lqYeri2BAV5dTVOg81FgfBqZzFhPLjVXE=";
+
+    @Test
+    void roundTrip_128bit_plainAscii() {
+        String pt = "hello world";
+        String ct = AesCryptoUtils.encrypt(pt, KEY_128);
+        String out = AesCryptoUtils.decrypt(ct, KEY_128);
+        assertEquals(pt, out);
+    }
+
+    @Test
+    void roundTrip_192bit_nonAscii() {
+        String pt = "£€漢字";
+        String ct = AesCryptoUtils.encrypt(pt, KEY_192);
+        String out = AesCryptoUtils.decrypt(ct, KEY_192);
+        assertEquals(pt, out);
+    }
+
+    @Test
+    void roundTrip_256bit_emptyString() {
+        String pt = "";
+        String ct = AesCryptoUtils.encrypt(pt, KEY_256);
+        String out = AesCryptoUtils.decrypt(ct, KEY_256);
+        assertEquals(pt, out);
+    }
+
+    @Test
+    void encrypt_producesDifferentCiphertexts_dueToRandomIv() {
+        String pt = "same text";
+        String c1 = AesCryptoUtils.encrypt(pt, KEY_256);
+        String c2 = AesCryptoUtils.encrypt(pt, KEY_256);
+        assertNotEquals(c1, c2);
+    }
+
+    @Test
+    void ciphertext_isBase64_andContainsIvPrefix() {
+        String pt = "check structure";
+        String ct = AesCryptoUtils.encrypt(pt, KEY_128);
+        byte[] decoded = Base64.getDecoder().decode(ct);
+        // IV (12) + tag (16) + ciphertext (>=0)
+        assertTrue(decoded.length >= 12 + 16);
+    }
+
+    @Test
+    void decrypt_withWrongKey_fails() {
+        String pt = "secret";
+        String ct = AesCryptoUtils.encrypt(pt, KEY_128);
+        assertThrows(IllegalStateException.class, () -> AesCryptoUtils.decrypt(ct, KEY_256));
+    }
+
+    @Test
+    void encrypt_withBlankKey_throws() {
+        assertThrows(IllegalArgumentException.class, () -> AesCryptoUtils.encrypt("x", ""));
+    }
+
+    @Test
+    void encrypt_withBadLengthKey_throws() {
+        // 15-byte key (invalid)
+        String badKey = Base64.getEncoder().encodeToString(new byte[15]);
+        assertThrows(IllegalArgumentException.class, () -> AesCryptoUtils.encrypt("x", badKey));
+    }
+
+    @Test
+    void decrypt_shortCiphertext_fails() {
+        // Base64 of 2 bytes, shorter than IV
+        String shortCt = "AA==";
+        assertThrows(IllegalStateException.class, () -> AesCryptoUtils.decrypt(shortCt, KEY_128));
+    }
+
+    @Test
+    void decrypt_badBase64_fails() {
+        String notB64 = "%%%not-base64%%%";
+        assertThrows(IllegalStateException.class, () -> AesCryptoUtils.decrypt(notB64, KEY_128));
+    }
+
+    @Test
+    void tamper_ciphertext_failsAuth() {
+        String pt = "auth check";
+        String ct = AesCryptoUtils.encrypt(pt, KEY_256);
+        byte[] bytes = Base64.getDecoder().decode(ct);
+        bytes[bytes.length - 1] ^= 0x01; // flip last bit
+        String tampered = Base64.getEncoder().encodeToString(bytes);
+        assertThrows(IllegalStateException.class, () -> AesCryptoUtils.decrypt(tampered, KEY_256));
+    }
+}

--- a/src/test/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtilsTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtilsTest.java
@@ -19,39 +19,39 @@ class AesCryptoUtilsTest {
     @Test
     void roundTrip_128bit_plainAscii() {
         String pt = "hello world";
-        String ct = AesCryptoUtils.encrypt(pt, KEY_128);
-        String out = AesCryptoUtils.decrypt(ct, KEY_128);
+        String ct = AesCryptoUtil.encrypt(pt, KEY_128);
+        String out = AesCryptoUtil.decrypt(ct, KEY_128);
         assertEquals(pt, out);
     }
 
     @Test
     void roundTrip_192bit_nonAscii() {
         String pt = "£€漢字";
-        String ct = AesCryptoUtils.encrypt(pt, KEY_192);
-        String out = AesCryptoUtils.decrypt(ct, KEY_192);
+        String ct = AesCryptoUtil.encrypt(pt, KEY_192);
+        String out = AesCryptoUtil.decrypt(ct, KEY_192);
         assertEquals(pt, out);
     }
 
     @Test
     void roundTrip_256bit_emptyString() {
         String pt = "";
-        String ct = AesCryptoUtils.encrypt(pt, KEY_256);
-        String out = AesCryptoUtils.decrypt(ct, KEY_256);
+        String ct = AesCryptoUtil.encrypt(pt, KEY_256);
+        String out = AesCryptoUtil.decrypt(ct, KEY_256);
         assertEquals(pt, out);
     }
 
     @Test
     void encrypt_producesDifferentCiphertexts_dueToRandomIv() {
         String pt = "same text";
-        String c1 = AesCryptoUtils.encrypt(pt, KEY_256);
-        String c2 = AesCryptoUtils.encrypt(pt, KEY_256);
+        String c1 = AesCryptoUtil.encrypt(pt, KEY_256);
+        String c2 = AesCryptoUtil.encrypt(pt, KEY_256);
         assertNotEquals(c1, c2);
     }
 
     @Test
     void ciphertext_isBase64_andContainsIvPrefix() {
         String pt = "check structure";
-        String ct = AesCryptoUtils.encrypt(pt, KEY_128);
+        String ct = AesCryptoUtil.encrypt(pt, KEY_128);
         byte[] decoded = Base64.getDecoder().decode(ct);
         // IV (12) + tag (16) + ciphertext (>=0)
         assertTrue(decoded.length >= 12 + 16);
@@ -60,42 +60,42 @@ class AesCryptoUtilsTest {
     @Test
     void decrypt_withWrongKey_fails() {
         String pt = "secret";
-        String ct = AesCryptoUtils.encrypt(pt, KEY_128);
-        assertThrows(IllegalStateException.class, () -> AesCryptoUtils.decrypt(ct, KEY_256));
+        String ct = AesCryptoUtil.encrypt(pt, KEY_128);
+        assertThrows(IllegalStateException.class, () -> AesCryptoUtil.decrypt(ct, KEY_256));
     }
 
     @Test
     void encrypt_withBlankKey_throws() {
-        assertThrows(IllegalArgumentException.class, () -> AesCryptoUtils.encrypt("x", ""));
+        assertThrows(IllegalArgumentException.class, () -> AesCryptoUtil.encrypt("x", ""));
     }
 
     @Test
     void encrypt_withBadLengthKey_throws() {
         // 15-byte key (invalid)
         String badKey = Base64.getEncoder().encodeToString(new byte[15]);
-        assertThrows(IllegalArgumentException.class, () -> AesCryptoUtils.encrypt("x", badKey));
+        assertThrows(IllegalArgumentException.class, () -> AesCryptoUtil.encrypt("x", badKey));
     }
 
     @Test
     void decrypt_shortCiphertext_fails() {
         // Base64 of 2 bytes, shorter than IV
         String shortCt = "AA==";
-        assertThrows(IllegalStateException.class, () -> AesCryptoUtils.decrypt(shortCt, KEY_128));
+        assertThrows(IllegalStateException.class, () -> AesCryptoUtil.decrypt(shortCt, KEY_128));
     }
 
     @Test
     void decrypt_badBase64_fails() {
         String notB64 = "%%%not-base64%%%";
-        assertThrows(IllegalStateException.class, () -> AesCryptoUtils.decrypt(notB64, KEY_128));
+        assertThrows(IllegalStateException.class, () -> AesCryptoUtil.decrypt(notB64, KEY_128));
     }
 
     @Test
     void tamper_ciphertext_failsAuth() {
         String pt = "auth check";
-        String ct = AesCryptoUtils.encrypt(pt, KEY_256);
+        String ct = AesCryptoUtil.encrypt(pt, KEY_256);
         byte[] bytes = Base64.getDecoder().decode(ct);
         bytes[bytes.length - 1] ^= 0x01; // flip last bit
         String tampered = Base64.getEncoder().encodeToString(bytes);
-        assertThrows(IllegalStateException.class, () -> AesCryptoUtils.decrypt(tampered, KEY_256));
+        assertThrows(IllegalStateException.class, () -> AesCryptoUtil.decrypt(tampered, KEY_256));
     }
 }

--- a/src/test/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtilsTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/utils/AesCryptoUtilsTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
-
 import uk.gov.dbt.ndtp.federator.exceptions.AesCryptographicOperationException;
 
 class AesCryptoUtilsTest {

--- a/src/test/java/uk/gov/dbt/ndtp/federator/utils/RedisUtilTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/utils/RedisUtilTest.java
@@ -26,8 +26,11 @@
 
 package uk.gov.dbt.ndtp.federator.utils;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redis.testcontainers.RedisContainer;
 import java.io.File;
@@ -98,6 +101,32 @@ class RedisUtilTest {
         String stored = pool.get("topic:" + RANDOM_CLIENT + "-" + RANDOM_TOPIC + ":offset");
         assertEquals(String.valueOf(RANDOM_OFFSET), stored);
     }
+
+    @Test
+    void setValue_getValue_noTtl_noEncryption() {
+        String key = "plain_no_ttl";
+        String val = "hello";
+        assertTrue(underTest.setValue(key, val, false, null));
+        assertEquals(val, underTest.getValue(key, String.class, false));
+        assertEquals(-1L, pool.ttl(key)); // no TTL set
+    }
+
+    @Test
+    void setValue_getValue_withTtl_noEncryption() throws Exception {
+        String key = "plain_with_ttl";
+        String val = "hello-ttl";
+        long ttl = 2L;
+        assertTrue(underTest.setValue(key, val, false, ttl));
+
+        assertEquals(val, underTest.getValue(key, String.class, false));
+        long redisTtl = pool.ttl(key);
+        assertTrue(redisTtl > 0 && redisTtl <= ttl);
+
+        Thread.sleep(2500);
+        assertNull(underTest.getValue(key, String.class, false));
+        assertNull(pool.get(key));
+    }
+
 
     @Nested
     class Initialising {
@@ -195,6 +224,79 @@ class RedisUtilTest {
 
             String smokeTestValue = pool.get("topic:smoke_test_client-smoke_test_topic:offset");
             assertEquals("-150", smokeTestValue);
+        }
+    }
+
+    @Nested
+    class InitialisingWithEncryption {
+
+        private static final String KEY_B64 = "Bg7HhP2hl/lqYeri2BAV5dTVOg81FgfBqZzFhPLjVXE="; // 32-byte key
+        private RedisUtil encUtil;
+
+        @BeforeAll
+        static void beforeAll() throws Exception {
+            TestPropertyUtil.clearProperties();
+
+            Path tmp = Files.createTempFile(null, null);
+            Files.writeString(
+                    tmp,
+                    """
+                            redis.host=%s
+                            redis.port=%d
+                            redis.tls.enabled=false
+                            redis.aes.key=%s
+                            """
+                            .formatted(redis.getRedisHost(), redis.getRedisPort(), KEY_B64));
+            File tmpProperties = tmp.toFile();
+            tmpProperties.deleteOnExit();
+            PropertyUtil.init(tmpProperties);
+
+            var f = RedisUtil.class.getDeclaredField("instance");
+            f.setAccessible(true);
+            f.set(null, null);
+        }
+
+        @AfterAll
+        static void afterAll() throws Exception {
+            TestPropertyUtil.clearProperties();
+            var f = RedisUtil.class.getDeclaredField("instance");
+            f.setAccessible(true);
+            f.set(null, null);
+        }
+
+        @BeforeEach
+        void init() {
+            encUtil = RedisUtil.getInstance(); // loads AES key
+        }
+
+        @Test
+        void setValue_getValue_noTtl_withEncryption() {
+            String key = "enc_no_ttl";
+            String val = "secret";
+            assertTrue(encUtil.setValue(key, val, true, null));
+
+            String raw = pool.get(key);
+            assertNotNull(raw);
+            assertNotEquals(val, raw); // not plaintext
+
+            assertEquals(val, encUtil.getValue(key, String.class, true));
+            assertEquals(-1L, pool.ttl(key)); // no TTL set
+        }
+
+        @Test
+        void setValue_getValue_withTtl_withEncryption() throws Exception {
+            String key = "enc_with_ttl";
+            String val = "secret-ttl";
+            long ttl = 2L;
+            assertTrue(encUtil.setValue(key, val, true, ttl));
+
+            assertEquals(val, encUtil.getValue(key, String.class, true));
+            long redisTtl = pool.ttl(key);
+            assertTrue(redisTtl > 0 && redisTtl <= ttl);
+
+            Thread.sleep(2500);
+            assertNull(encUtil.getValue(key, String.class, true));
+            assertNull(pool.get(key));
         }
     }
 }

--- a/src/test/java/uk/gov/dbt/ndtp/federator/utils/RedisUtilTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/utils/RedisUtilTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.exceptions.JedisDataException;
 
 @Testcontainers
 class RedisUtilTest {
@@ -111,7 +112,7 @@ class RedisUtilTest {
     }
 
     @Test
-    void setValue_getValue_withTtl_noEncryption() throws Exception {
+    void setValue_getValue_withTtl_noEncryption() throws JedisDataException {
         String key = "plain_with_ttl";
         String val = "hello-ttl";
         long ttl = 60L;
@@ -279,7 +280,7 @@ class RedisUtilTest {
         }
 
         @Test
-        void setValue_getValue_withTtl_withEncryption() throws Exception {
+        void setValue_getValue_withTtl_withEncryption() throws JedisDataException {
             String key = "enc_with_ttl";
             String val = "secret-ttl";
             long ttl = 50L;

--- a/src/test/java/uk/gov/dbt/ndtp/federator/utils/RedisUtilTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/utils/RedisUtilTest.java
@@ -26,7 +26,6 @@
 
 package uk.gov.dbt.ndtp.federator.utils;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -106,7 +105,7 @@ class RedisUtilTest {
     void setValue_getValue_noTtl_noEncryption() {
         String key = "plain_no_ttl";
         String val = "hello";
-        assertTrue(underTest.setValue(key, val, false, null));
+        assertTrue(underTest.setValue(key, val, null));
         assertEquals(val, underTest.getValue(key, String.class, false));
         assertEquals(-1L, pool.ttl(key)); // no TTL set
     }
@@ -115,16 +114,13 @@ class RedisUtilTest {
     void setValue_getValue_withTtl_noEncryption() throws Exception {
         String key = "plain_with_ttl";
         String val = "hello-ttl";
-        long ttl = 2L;
-        assertTrue(underTest.setValue(key, val, false, ttl));
+        long ttl = 60L;
+        assertTrue(underTest.setValue(key, val, ttl));
 
         assertEquals(val, underTest.getValue(key, String.class, false));
         long redisTtl = pool.ttl(key);
         assertTrue(redisTtl > 0 && redisTtl <= ttl);
-
-        Thread.sleep(2500);
-        assertNull(underTest.getValue(key, String.class, false));
-        assertNull(pool.get(key));
+        assertNotNull(underTest.getValue(key, String.class, false));
     }
 
     @Nested
@@ -272,7 +268,7 @@ class RedisUtilTest {
         void setValue_getValue_noTtl_withEncryption() {
             String key = "enc_no_ttl";
             String val = "secret";
-            assertTrue(encUtil.setValue(key, val, true, null));
+            assertTrue(encUtil.setValue(key, val, null));
 
             String raw = pool.get(key);
             assertNotNull(raw);
@@ -286,16 +282,14 @@ class RedisUtilTest {
         void setValue_getValue_withTtl_withEncryption() throws Exception {
             String key = "enc_with_ttl";
             String val = "secret-ttl";
-            long ttl = 2L;
-            assertTrue(encUtil.setValue(key, val, true, ttl));
+            long ttl = 50L;
+            assertTrue(encUtil.setValue(key, val, ttl));
 
             assertEquals(val, encUtil.getValue(key, String.class, true));
             long redisTtl = pool.ttl(key);
             assertTrue(redisTtl > 0 && redisTtl <= ttl);
 
-            Thread.sleep(2500);
-            assertNull(encUtil.getValue(key, String.class, true));
-            assertNull(pool.get(key));
+            assertNotNull(encUtil.getValue(key, String.class, true));
         }
     }
 }

--- a/src/test/java/uk/gov/dbt/ndtp/federator/utils/RedisUtilTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/utils/RedisUtilTest.java
@@ -127,7 +127,6 @@ class RedisUtilTest {
         assertNull(pool.get(key));
     }
 
-
     @Nested
     class Initialising {
         @BeforeAll

--- a/src/test/resources/client.properties
+++ b/src/test/resources/client.properties
@@ -28,5 +28,7 @@ redis.tls.enabled=false
 # If redis authentication is enabled then set the username and password here. If only a password is required then keep the username as an empty string.
 redis.username=
 redis.password=
+# For access token cached in Redis set this property to an AES key (Base64 encoded) for encryption/decryption purposes.
+redis.aes.key=
 connections.configuration=src/test/resources/connection-configuration.json
 common.configuration=src/test/resources/common-configuration.properties

--- a/src/test/resources/common-configuration.properties
+++ b/src/test/resources/common-configuration.properties
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Originally developed by Telicent Ltd.; subsequently adapted, enhanced, and maintained by the National Digital Twin Programme.
+
 # common-configuration.properties
 
 # ============================================
@@ -9,6 +12,9 @@ idp.jwks.url=${IDP_JWKS_URL}
 
 # Token endpoint URL of the IDP (used to fetch OAuth2 tokens)
 idp.token.url=${IDP_TOKEN_URL}
+
+# Backoff time in milliseconds before retrying a failed token request (default: 1000 ms)
+idp.token.backoff=1000
 
 # OAuth2 client ID (registered with the IDP)
 idp.client.id=${IDP_CLIENT_ID}


### PR DESCRIPTION
## Sensitive Credential Checks

- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
Adds support for caching of access token per management node using Redis. Optionally, a key can be supplied through configuration to encrypt contents of persisted keys prior to their storage in Redis.

## Description
Implements an AES encryption helper, Redis methods to store and retrieve JSON serialised object values (using generics), a unilateral solution for encrypting Redis contents and logic to cache tokens to relieve excessive calls to management node IDP providers.

## How Has This Been Tested?
Tested locally in both Redis encrypted and non-encrypted scenarios.

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [X] Includes link to an issue (if apply)
- [X] I have added tests to cover my changes