### PR TITLE
bugfix(DPAV-1766): fix offset tracking for consumers

### DIFF
--- a/src/main/java/uk/gov/dbt/ndtp/federator/grpc/GRPCClient.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/grpc/GRPCClient.java
@@ -243,7 +243,6 @@ public class GRPCClient implements AutoCloseable {
 
     public void processTopic(String topic, long offset) {
         LOGGER.info("Processing topic: {}", topic);
-        // This does a smoke test so hopefully fail early if problems.
         RedisUtil.getInstance();
         TopicRequest topicRequest = TopicRequest.newBuilder()
                 .setTopic(topic)

--- a/src/main/java/uk/gov/dbt/ndtp/federator/jobs/handlers/ClientGRPCJob.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/jobs/handlers/ClientGRPCJob.java
@@ -61,7 +61,7 @@ public class ClientGRPCJob implements Job {
                 request.getTopic());
         try {
             WrappedGRPCClient grpcClient = clientFactory.apply(connectionProperties, prefix);
-            long offset = offsetProvider.applyAsLong(prefix, request.getTopic());
+            long offset = offsetProvider.applyAsLong(grpcClient.getRedisPrefix(), request.getTopic());
             grpcClient.processTopic(request.getTopic(), offset);
         } catch (Exception e) {
             throw new ClientGRPCJobException("Failed to process topic '" + request.getTopic() + "' via GRPC client", e);

--- a/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceMtlsImpl.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceMtlsImpl.java
@@ -11,6 +11,9 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Map;
 import java.util.Properties;
+
+import org.apache.commons.lang3.StringUtils;
+
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.dbt.ndtp.federator.exceptions.FederatorTokenException;
 import uk.gov.dbt.ndtp.federator.utils.PropertyUtil;
@@ -121,7 +124,12 @@ public class IdpTokenServiceMtlsImpl extends AbstractIdpTokenService {
         String redisKey = getRedisKey(managementNodeId);
         String cachedToken = RedisUtil.getInstance().getValue(redisKey, String.class, true);
         if (cachedToken != null) {
-            log.debug("Using cached access token from Redis for management node {}", managementNodeId);
+            if (StringUtils.isBlank(managementNodeId)) {
+                log.debug("Using cached access token from Redis for default management node");
+            }
+            else {
+                log.debug("Using cached access token from Redis for management node {}", managementNodeId);                
+            }
         }
         return cachedToken;
     }

--- a/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceMtlsImpl.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/service/IdpTokenServiceMtlsImpl.java
@@ -104,7 +104,12 @@ public class IdpTokenServiceMtlsImpl extends AbstractIdpTokenService {
             String accessToken = (String) json.get(ACCESS_TOKEN);
             long expiresIn = ((Number) json.get("expires_in")).longValue(); // seconds
 
-            log.info("Access token fetched for management node {}, persisting to Redis", managementNodeId);
+            if (StringUtils.isBlank(managementNodeId)) {
+                log.info("Access token fetched for default management node, persisting to Redis");
+            } else {
+                log.info("Access token fetched for management node {}, persisting to Redis", managementNodeId);
+            }
+
             persistTokenInCache(managementNodeId, accessToken, expiresIn);
 
             return accessToken;

--- a/src/main/java/uk/gov/dbt/ndtp/federator/utils/RedisUtil.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/utils/RedisUtil.java
@@ -176,9 +176,8 @@ public class RedisUtil {
     }
 
     private String setOffset(String key, long value) {
-        key = qualifyOffset(key);
         LOGGER.debug("Persisting offset in redis {} = {}", key, value);
-        setValue(key, value);
+        setValue(qualifyOffset(key), value);
         return "OK";
     }
 
@@ -196,7 +195,7 @@ public class RedisUtil {
      * @return true if Redis SET returned "OK"
      */
     public <T> boolean setValue(String key, T value) {
-        return setValue(getPrefixedKey(key), value, null);
+        return setValue(key, value, null);
     }
 
     /**

--- a/src/test/java/uk/gov/dbt/ndtp/federator/jobs/handlers/ClientGRPCJobTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/jobs/handlers/ClientGRPCJobTest.java
@@ -23,6 +23,7 @@ class ClientGRPCJobTest {
         when(offsetProvider.applyAsLong("pref", "topic-a")).thenReturn(42L);
 
         WrappedGRPCClient wrapped = mock(WrappedGRPCClient.class);
+        when(wrapped.getRedisPrefix()).thenReturn("pref"); 
         BiFunction<ConnectionProperties, String, WrappedGRPCClient> clientFactory = mock(BiFunction.class);
 
         ConnectionProperties cp = new ConnectionProperties("cName", "cKey", "sName", "localhost", 8080, false);
@@ -42,6 +43,7 @@ class ClientGRPCJobTest {
         verify(clientFactory, times(1)).apply(cp, "pref");
         verify(offsetProvider, times(1)).applyAsLong("pref", "topic-a");
         verify(wrapped, times(1)).processTopic("topic-a", 42L);
+        verify(wrapped, times(1)).getRedisPrefix();
         verifyNoMoreInteractions(wrapped);
     }
 
@@ -53,6 +55,7 @@ class ClientGRPCJobTest {
         when(offsetProvider.applyAsLong("", "t")).thenReturn(0L);
 
         WrappedGRPCClient wrapped = mock(WrappedGRPCClient.class);
+        when(wrapped.getRedisPrefix()).thenReturn("");
         BiFunction<ConnectionProperties, String, WrappedGRPCClient> clientFactory = mock(BiFunction.class);
 
         ConnectionProperties cp = new ConnectionProperties("c", "k", "S", "127.0.0.1", 8081, true);
@@ -82,6 +85,7 @@ class ClientGRPCJobTest {
 
         WrappedGRPCClient wrapped = mock(WrappedGRPCClient.class);
         BiFunction<ConnectionProperties, String, WrappedGRPCClient> clientFactory = mock(BiFunction.class);
+        when(wrapped.getRedisPrefix()).thenReturn("pref");
 
         ConnectionProperties cp = new ConnectionProperties("c", "k", "s", "host", 9090, false);
         when(clientFactory.apply(cp, "pref")).thenReturn(wrapped);


### PR DESCRIPTION
## Sensitive Credential Checks

- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
Fixes tracking of offsets for consumers, which if incorrect, would lead to data duplication in Kafka topics.

## Description
Fixes offset tracking by correcting key consistency when persisting and retrieving offsets from Redis.

## How Has This Been Tested?
Tested locally using remote Kafka topics, and unit tests.

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [X] Includes link to an issue (if apply)
- [X] I have added tests to cover my changes.

