### PR TITLE
Feature/dpav fix server disconnet

### DIFF
--- a/src/main/java/uk/gov/dbt/ndtp/federator/consumer/KafkaEventMessageConsumer.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/consumer/KafkaEventMessageConsumer.java
@@ -26,9 +26,6 @@
 
 package uk.gov.dbt.ndtp.federator.consumer;
 
-// Avoid static imports from KafkaUtil to prevent class initialization during tests
-// Property keys duplicated here to avoid early KafkaUtil initialization
-
 import java.time.Duration;
 import java.time.Instant;
 import org.slf4j.Logger;

--- a/src/main/java/uk/gov/dbt/ndtp/federator/grpc/GRPCClient.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/grpc/GRPCClient.java
@@ -262,8 +262,10 @@ public class GRPCClient implements AutoCloseable {
                 } else {
                     LOGGER.error("Topic processing stopped due to unknown error.", exception);
                 }
+                throw exception;
             } catch (Exception exception) {
                 LOGGER.error("Topic processing stopped due to error.", exception);
+                throw exception;
             }
         } catch (KafkaException e) {
             LOGGER.warn("Failed to create KafkaSink - '{}'", e.getMessage());

--- a/src/main/java/uk/gov/dbt/ndtp/federator/jobs/handlers/ClientGRPCJob.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/jobs/handlers/ClientGRPCJob.java
@@ -60,10 +60,10 @@ public class ClientGRPCJob implements Job {
                 connectionProperties.serverHost(),
                 request.getTopic());
         try {
-            try (WrappedGRPCClient grpcClient = clientFactory.apply(connectionProperties, prefix)) {
+        WrappedGRPCClient grpcClient = clientFactory.apply(connectionProperties, prefix);
                 long offset = offsetProvider.applyAsLong(grpcClient.getRedisPrefix(), request.getTopic());
                 grpcClient.processTopic(request.getTopic(), offset);
-            }
+
         } catch (Exception e) {
             throw new ClientGRPCJobException("Failed to process topic '" + request.getTopic() + "' via GRPC client", e);
         }

--- a/src/main/java/uk/gov/dbt/ndtp/federator/jobs/handlers/ClientGRPCJob.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/jobs/handlers/ClientGRPCJob.java
@@ -60,9 +60,9 @@ public class ClientGRPCJob implements Job {
                 connectionProperties.serverHost(),
                 request.getTopic());
         try {
-        WrappedGRPCClient grpcClient = clientFactory.apply(connectionProperties, prefix);
-                long offset = offsetProvider.applyAsLong(grpcClient.getRedisPrefix(), request.getTopic());
-                grpcClient.processTopic(request.getTopic(), offset);
+            WrappedGRPCClient grpcClient = clientFactory.apply(connectionProperties, prefix);
+            long offset = offsetProvider.applyAsLong(grpcClient.getRedisPrefix(), request.getTopic());
+            grpcClient.processTopic(request.getTopic(), offset);
 
         } catch (Exception e) {
             throw new ClientGRPCJobException("Failed to process topic '" + request.getTopic() + "' via GRPC client", e);

--- a/src/main/java/uk/gov/dbt/ndtp/federator/jobs/handlers/ClientGRPCJob.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/jobs/handlers/ClientGRPCJob.java
@@ -60,9 +60,10 @@ public class ClientGRPCJob implements Job {
                 connectionProperties.serverHost(),
                 request.getTopic());
         try {
-            WrappedGRPCClient grpcClient = clientFactory.apply(connectionProperties, prefix);
-            long offset = offsetProvider.applyAsLong(grpcClient.getRedisPrefix(), request.getTopic());
-            grpcClient.processTopic(request.getTopic(), offset);
+            try (WrappedGRPCClient grpcClient = clientFactory.apply(connectionProperties, prefix)) {
+                long offset = offsetProvider.applyAsLong(grpcClient.getRedisPrefix(), request.getTopic());
+                grpcClient.processTopic(request.getTopic(), offset);
+            }
         } catch (Exception e) {
             throw new ClientGRPCJobException("Failed to process topic '" + request.getTopic() + "' via GRPC client", e);
         }

--- a/src/main/java/uk/gov/dbt/ndtp/federator/utils/KafkaUtil.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/utils/KafkaUtil.java
@@ -64,24 +64,6 @@ public class KafkaUtil {
 
     public static final Logger LOGGER = LoggerFactory.getLogger("KafkaUtil");
 
-    static {
-        boolean isValidProperties = true;
-        String bootstrapServer = PropertyUtil.getPropertyValue(KAFKA_BOOTSTRAP_SERVERS);
-        if (null == bootstrapServer || bootstrapServer.isEmpty()) {
-            LOGGER.error("KafkaUtil property '{}' not correctly set", KAFKA_BOOTSTRAP_SERVERS);
-            isValidProperties = false;
-        }
-        String consumerGroup = PropertyUtil.getPropertyValue(KAFKA_CONSUMER_GROUP);
-        if (null == consumerGroup || consumerGroup.isEmpty()) {
-            LOGGER.error("KafkaUtil property '{}' not correctly set", KAFKA_CONSUMER_GROUP);
-            isValidProperties = false;
-        }
-        if (!isValidProperties) {
-            LOGGER.error("Problem with the properties for KafkaUtil. Exit early.");
-            throw new RuntimeException("Problem with the properties for KafkaUtil. Exit early.");
-        }
-    }
-
     private KafkaUtil() {}
 
     public static <Key, Value> KafkaEventSource.Builder<Key, Value> getKafkaSourceBuilder() {

--- a/src/test/java/uk/gov/dbt/ndtp/federator/consumer/KafkaEventMessageConsumerAdditionalTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/consumer/KafkaEventMessageConsumerAdditionalTest.java
@@ -37,8 +37,7 @@ class KafkaEventMessageConsumerAdditionalTest {
         when(mockKafkaBuilder.keyDeserializer(StringDeserializer.class)).thenReturn(mockKafkaBuilder);
         when(mockKafkaBuilder.valueDeserializer(StringDeserializer.class)).thenReturn(mockKafkaBuilder);
         when(mockKafkaBuilder.topic("TOPIC")).thenReturn(mockKafkaBuilder);
-        when(mockKafkaBuilder.consumerGroup("CLIENT"))
-                .thenReturn(mockKafkaBuilder);
+        when(mockKafkaBuilder.consumerGroup("CLIENT")).thenReturn(mockKafkaBuilder);
         when(mockKafkaBuilder.readPolicy(any())).thenReturn(mockKafkaBuilder);
         when(mockKafkaBuilder.build()).thenReturn(mockEventSource);
         // Default: source isn't closed unless we explicitly close it

--- a/src/test/java/uk/gov/dbt/ndtp/federator/consumer/KafkaEventMessageConsumerAdditionalTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/consumer/KafkaEventMessageConsumerAdditionalTest.java
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+package uk.gov.dbt.ndtp.federator.consumer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static uk.gov.dbt.ndtp.federator.utils.TestPropertyUtil.setUpProperties;
+
+import java.time.Duration;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import uk.gov.dbt.ndtp.federator.utils.KafkaUtil;
+import uk.gov.dbt.ndtp.federator.utils.PropertyUtil;
+import uk.gov.dbt.ndtp.secure.agent.sources.kafka.KafkaEventSource;
+
+/**
+ * Additional focused tests for KafkaEventMessageConsumer to cover inactivity timeout and close delegation.
+ */
+class KafkaEventMessageConsumerAdditionalTest {
+
+    private static final KafkaEventSource.Builder mockKafkaBuilder = mock(KafkaEventSource.Builder.class);
+    private static final KafkaEventSource mockEventSource = mock(KafkaEventSource.class);
+    private static final MockedStatic<KafkaUtil> mockedKafkaUtil = Mockito.mockStatic(KafkaUtil.class);
+
+    @BeforeAll
+    static void beforeAll() {
+        setUpProperties();
+        mockedKafkaUtil.when(KafkaUtil::getKafkaSourceBuilder).thenReturn(mockKafkaBuilder);
+        when(mockKafkaBuilder.keyDeserializer(StringDeserializer.class)).thenReturn(mockKafkaBuilder);
+        when(mockKafkaBuilder.valueDeserializer(StringDeserializer.class)).thenReturn(mockKafkaBuilder);
+        when(mockKafkaBuilder.topic("TOPIC")).thenReturn(mockKafkaBuilder);
+        when(mockKafkaBuilder.consumerGroup("CLIENT"))
+                .thenReturn(mockKafkaBuilder);
+        when(mockKafkaBuilder.readPolicy(any())).thenReturn(mockKafkaBuilder);
+        when(mockKafkaBuilder.build()).thenReturn(mockEventSource);
+        // Default: source isn't closed unless we explicitly close it
+        when(mockEventSource.isClosed()).thenReturn(false);
+        // Allow close() without side-effects
+        doNothing().when(mockEventSource).close();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        mockedKafkaUtil.close();
+    }
+
+    @Test
+    void stillAvailable_returns_false_and_closes_on_inactivity_timeout_zero() {
+        // ensure no interference from other tests using the same mock
+        reset(mockEventSource);
+        when(mockEventSource.isClosed()).thenReturn(false);
+        doNothing().when(mockEventSource).close();
+
+        try (MockedStatic<PropertyUtil> mockedProps = Mockito.mockStatic(PropertyUtil.class)) {
+            // Make both pollDuration and inactivityTimeout be zero to trigger immediate timeout on first check
+            mockedProps
+                    .when(() -> PropertyUtil.getPropertyDurationValue(anyString(), anyString()))
+                    .thenReturn(Duration.ZERO);
+
+            KafkaEventMessageConsumer<String, String> consumer = new KafkaEventMessageConsumer<>(
+                    StringDeserializer.class, StringDeserializer.class, "TOPIC", 0L, "CLIENT");
+
+            boolean available = consumer.stillAvailable();
+
+            assertFalse(available, "Consumer should report unavailable due to immediate inactivity timeout");
+            verify(mockEventSource, times(1)).close();
+        }
+    }
+
+    @Test
+    void close_delegates_to_underlying_source() {
+        KafkaEventMessageConsumer<String, String> consumer = new KafkaEventMessageConsumer<>(
+                StringDeserializer.class, StringDeserializer.class, "TOPIC", 0L, "CLIENT");
+
+        consumer.close();
+
+        verify(mockEventSource, times(1)).close();
+    }
+}

--- a/src/test/java/uk/gov/dbt/ndtp/federator/grpc/GRPCClientAdditionalTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/grpc/GRPCClientAdditionalTest.java
@@ -24,7 +24,9 @@ class GRPCClientAdditionalTest {
         when(channel.shutdown()).thenReturn(channel);
         try (MockedStatic<GRPCClient> grpcStatic = mockStatic(GRPCClient.class)) {
             // Let unspecified static methods call real methods
-            grpcStatic.when(() -> GRPCClient.generateChannel(anyString(), anyInt())).thenReturn(channel);
+            grpcStatic
+                    .when(() -> GRPCClient.generateChannel(anyString(), anyInt()))
+                    .thenReturn(channel);
             // Build client with TLS disabled so it uses generateChannel
             GRPCClient client = new GRPCClient("client", "key", "server", "host", 1234, false, "pref");
 

--- a/src/test/java/uk/gov/dbt/ndtp/federator/grpc/GRPCClientAdditionalTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/grpc/GRPCClientAdditionalTest.java
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+package uk.gov.dbt.ndtp.federator.grpc;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import io.grpc.ManagedChannel;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Additional coverage for GRPCClient focusing on non-TLS channel path and close behavior.
+ */
+class GRPCClientAdditionalTest {
+
+    @Test
+    void constructor_nonTls_uses_generateChannel_and_close_shuts_down_channel() throws Exception {
+        ManagedChannel channel = mock(ManagedChannel.class);
+        when(channel.shutdown()).thenReturn(channel);
+        try (MockedStatic<GRPCClient> grpcStatic = mockStatic(GRPCClient.class)) {
+            // Let unspecified static methods call real methods
+            grpcStatic.when(() -> GRPCClient.generateChannel(anyString(), anyInt())).thenReturn(channel);
+            // Build client with TLS disabled so it uses generateChannel
+            GRPCClient client = new GRPCClient("client", "key", "server", "host", 1234, false, "pref");
+
+            grpcStatic.verify(() -> GRPCClient.generateChannel("host", 1234));
+
+            // When closing, ensure the underlying channel is shutdown
+            client.close();
+            verify(channel, times(1)).shutdown();
+            verify(channel, times(1)).awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+}


### PR DESCRIPTION
## Sensitive Credential Checks

- [X ] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ X] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.


## Motivation and Context
There has been an identified behaviour which was making both server and client to remain connected for the streaming purpose. 
this PR aims to fix that on the server side by checking the kafka inactivity period. this means that if the kafka client has no data to deliver to the GRPC, after a period of timeout, it should close the connections.

one other fix in here is the jobRunner Failure capability. in the past all jobs regardless of their actual success or failure, they were being completed as successful. it is not handled property and retried if failed for whatever reason as shown in the screenshot



## How Has This Been Tested?
Yes
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1413" height="693" alt="image" src="https://github.com/user-attachments/assets/0adb88a3-c6da-46e1-8566-2bfa81d6302a" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [X ] I have added tests to cover my changes.

