### PR TITLE
fix:Message header alingment, send message data type

### DIFF
--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -31,7 +31,7 @@ RUN chown federator-service /library/ /app/
 WORKDIR /app
 USER federator-service
 ARG JAR_NAME
-COPY target/federator-server-1.0.0.jar /app/app.jar
+COPY target/federator-client-1.0.0.jar /app/app.jar
 ENTRYPOINT java -cp /app/app.jar:/library/* $PROPERTIES uk.gov.dbt.ndtp.federator.FederatorClient $ARGS
 
 # Federation Client with MSK auth support


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

During end-to-end testing of the Federator server and client communication, two critical issues were identified that prevented successful message federation and caused exceptions to be thrown during the gRPC streaming process.

## Description

During testing the following message was raised on the  Kafka knowledge topic

"Content-Type":"application/trig"

```
PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX veh:     <http://example.com/vehicle#>
PREFIX authz:   <http://ndtp.co.uk/security#>
PREFIX :        <http://example.com/data#>

:carGolf rdf:type veh:Car ;
    veh:make "Volkswagen" ;
    veh:model "Golf GTI" .

GRAPH authz:labels {
    [ authz:pattern "<http://example.com/data#carGolf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/vehicle#Car>" ;
      authz:label "*" ] .
    [ authz:pattern "<http://example.com/data#carGolf> <http://example.com/vehicle#make> \"Volkswagen\"" ;
      authz:label "*" ] .
    [ authz:pattern "<http://example.com/data#carGolf> <http://example.com/vehicle#model> \"Golf GTI\"" ;
      authz:label "*" ] .
}
```

This caused / highlighted the following.

Content-Type Header Mismatch in RdfKafkaEventMessageProcessor

Issue: The federator-server was serializing RDF payloads to N-Quads format but keeping the original Content-Type header from the source Kafka message (e.g., application/trig)
Impact: The federator-client received messages with incorrect Content-Type headers, causing RDF parsing failures
Fix: Updated RdfKafkaEventMessageProcessor.process() to filter out the original Content-Type header and add Content-Type: application/n-quads to match the serialized format


Type Mismatch in GRPCClient.sendMessage (Client-side)

Issue: The sendMessage() method signature expected KafkaSink<Bytes, Bytes> (Apache Kafka's Bytes wrapper type) but was receiving byte[] arrays from the gRPC batch, requiring conversion
Impact: Type incompatibility between gRPC message batches and Kafka sink requirements
Fix: Updated GRPCClient.sendMessage() to:
Accept KafkaSink<byte[], byte[]> instead of KafkaSink<Bytes, Bytes>
Remove unnecessary Bytes wrapper conversions
Directly pass byte[] arrays from batch.getKey().toByteArray() and batch.getValue().toByteArray() to the Kafka sink

## How Has This Been Tested?

With the changes in place i can now run an end to end test,

Raise message in Kafka -> Client request new messages -> GRPC -> Server picks up message -> GRPC Client-> Client post to Kafka -> graph node ingests data.


## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

