### PR TITLE
feat(DPAV-1868): support producer file streaming (Azure/AWS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ server.log
 /docker/docker-grpc-resources/minio-data/
 /docker/docker-grpc-resources/azurite-data/
 /.juni/
+/test-dest

--- a/src/main/java/uk/gov/dbt/ndtp/federator/client/grpc/GRPCFileClient.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/client/grpc/GRPCFileClient.java
@@ -84,6 +84,10 @@ public class GRPCFileClient extends GRPCAbstractClient {
         RedisUtil.getInstance();
         log.debug("Redis connectivity check passed");
 
+        if (destination == null || destination.isBlank()) {
+            throw new FileAssemblyException("Destination is required but was null/blank for topic '" + topic + "'");
+        }
+
         FileStreamRequest request = FileStreamRequest.newBuilder()
                 .setTopic(topic)
                 .setStartSequenceId(offset)
@@ -119,6 +123,6 @@ public class GRPCFileClient extends GRPCAbstractClient {
      * Backward-compatible overload without destination; defaults to provider configuration.
      */
     public void processTopic(String topic, long offset) {
-        processTopic(topic, offset, null);
+        throw new FileAssemblyException("Destination is required; use processTopic(topic, offset, destination)");
     }
 }

--- a/src/main/java/uk/gov/dbt/ndtp/federator/client/jobs/handlers/ClientGRPCFileExchangeJob.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/client/jobs/handlers/ClientGRPCFileExchangeJob.java
@@ -41,6 +41,11 @@ public class ClientGRPCFileExchangeJob implements Job {
         String topic = request.getTopic();
         String destinationPath = request.getFileExchangeProperties().getDestinationPath();
 
+        if (destinationPath == null || destinationPath.isBlank()) {
+            String msg = "Destination path is required but was null/blank for topic '" + topic + "'";
+            throw new ClientGRPCJobException(new IllegalArgumentException(msg));
+        }
+
         log.info(
                 "requesting topic:{}, source:{}, destination:{}",
                 topic,

--- a/src/test/java/uk/gov/dbt/ndtp/federator/client/grpc/GRPCFileClientTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/client/grpc/GRPCFileClientTest.java
@@ -10,6 +10,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import uk.gov.dbt.ndtp.federator.client.storage.ReceivedFileStorageFactory;
+import uk.gov.dbt.ndtp.federator.client.storage.StoredFileResult;
+import uk.gov.dbt.ndtp.federator.client.storage.impl.S3ReceivedFileStorage;
 import uk.gov.dbt.ndtp.federator.common.service.idp.IdpTokenService;
 import uk.gov.dbt.ndtp.federator.common.utils.GRPCUtils;
 import uk.gov.dbt.ndtp.federator.common.utils.PropertyUtil;
@@ -81,7 +84,7 @@ class GRPCFileClientTest {
             GRPCFileClient clientUnderTest = new GRPCFileClient(client, key, serverName, host, port, tls, topicPrefix);
 
             // Act
-            clientUnderTest.processTopic(topic, seqId);
+            clientUnderTest.processTopic(topic, seqId, "test-dest/");
 
             // Assert
             String expectedPrefix = client + "-" + serverName;
@@ -152,10 +155,115 @@ class GRPCFileClientTest {
             GRPCFileClient clientUnderTest = new GRPCFileClient(client, key, serverName, host, port, tls, topicPrefix);
 
             // Act + Assert
-            FileAssemblyException ex =
-                    assertThrows(FileAssemblyException.class, () -> clientUnderTest.processTopic(topic, seqId));
+            FileAssemblyException ex = assertThrows(
+                    FileAssemblyException.class, () -> clientUnderTest.processTopic(topic, seqId, "folder/"));
             assertTrue(ex.getMessage().contains("Unexpected error while processing file stream"));
 
+            verify(redisMock, never()).setOffset(anyString(), anyString(), anyLong());
+        } finally {
+            PropertyUtil.clear();
+        }
+    }
+
+    @Test
+    void processTopic_withoutDestination_throws() {
+        String client = "cli3";
+        String key = "k3";
+        String serverName = "srv3";
+        String host = "localhost";
+        int port = 50053;
+        boolean tls = false;
+        String topicPrefix = "tp3";
+        String topic = "files.nodest";
+
+        PropertyUtil.init("test.properties");
+        // Mock GRPCUtils to avoid loading configuration/SSL during client construction
+        IdpTokenService idpMock = mock(IdpTokenService.class);
+        try (MockedStatic<GRPCUtils> grpcUtilsStatic =
+                Mockito.mockStatic(GRPCUtils.class, Mockito.CALLS_REAL_METHODS)) {
+            grpcUtilsStatic.when(GRPCUtils::createIdpTokenService).thenReturn(idpMock);
+
+            GRPCFileClient clientUnderTest = new GRPCFileClient(client, key, serverName, host, port, tls, topicPrefix);
+            assertThrows(FileAssemblyException.class, () -> clientUnderTest.processTopic(topic, 0L));
+        } finally {
+            PropertyUtil.clear();
+        }
+    }
+
+    @Test
+    void processTopic_s3UploadFailure_doesNotSaveOffset() {
+        // Arrange
+        String client = "cli4";
+        String key = "k4";
+        String serverName = "srv4";
+        String host = "localhost";
+        int port = 50054;
+        boolean tls = false;
+        String topicPrefix = "tp4";
+        String topic = "files.s3fail";
+
+        long seqId = 31L;
+        byte[] data = "hello".getBytes();
+        long fileSize = data.length;
+
+        FileChunk dataChunk = FileChunk.newBuilder()
+                .setFileName("s3.txt")
+                .setChunkData(ByteString.copyFrom(data))
+                .setChunkIndex(0)
+                .setTotalChunks(1)
+                .setIsLastChunk(false)
+                .setFileSize(fileSize)
+                .setFileSequenceId(seqId)
+                .build();
+
+        FileChunk lastChunk = FileChunk.newBuilder()
+                .setFileName("s3.txt")
+                .setChunkIndex(1)
+                .setTotalChunks(1)
+                .setIsLastChunk(true)
+                .setFileSize(fileSize)
+                .setFileSequenceId(seqId)
+                .build();
+
+        Iterator<FileChunk> iterator = List.of(dataChunk, lastChunk).iterator();
+
+        FederatorServiceGrpc.FederatorServiceBlockingStub stub =
+                mock(FederatorServiceGrpc.FederatorServiceBlockingStub.class);
+        when(stub.getFilesStream(any(FileStreamRequest.class))).thenReturn(iterator);
+
+        RedisUtil redisMock = mock(RedisUtil.class);
+
+        // Initialize properties from test resources to avoid mocking PropertyUtil internals
+        PropertyUtil.init("test.properties");
+
+        // Mock GRPCUtils.createIdpTokenService to avoid SSL/truststore creation
+        IdpTokenService idpMock = mock(IdpTokenService.class);
+
+        // S3 storage that simulates failed upload by returning null remoteUri
+        class FailingS3 extends S3ReceivedFileStorage {
+            @Override
+            public StoredFileResult store(java.nio.file.Path localFile, String originalFileName, String destination) {
+                return new StoredFileResult(localFile.toAbsolutePath(), null);
+            }
+        }
+
+        try (MockedStatic<FederatorServiceGrpc> grpcStatic = Mockito.mockStatic(FederatorServiceGrpc.class);
+                MockedStatic<RedisUtil> redisStatic = Mockito.mockStatic(RedisUtil.class);
+                MockedStatic<GRPCUtils> grpcUtilsStatic =
+                        Mockito.mockStatic(GRPCUtils.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<ReceivedFileStorageFactory> storageFactoryStatic =
+                        Mockito.mockStatic(ReceivedFileStorageFactory.class)) {
+            grpcStatic.when(() -> FederatorServiceGrpc.newBlockingStub(any())).thenReturn(stub);
+            redisStatic.when(RedisUtil::getInstance).thenReturn(redisMock);
+            grpcUtilsStatic.when(GRPCUtils::createIdpTokenService).thenReturn(idpMock);
+            storageFactoryStatic.when(ReceivedFileStorageFactory::get).thenReturn(new FailingS3());
+
+            GRPCFileClient clientUnderTest = new GRPCFileClient(client, key, serverName, host, port, tls, topicPrefix);
+
+            // Act
+            clientUnderTest.processTopic(topic, seqId, "s3-prefix/");
+
+            // Assert: Redis offset must NOT be updated on S3 failure
             verify(redisMock, never()).setOffset(anyString(), anyString(), anyLong());
         } finally {
             PropertyUtil.clear();


### PR DESCRIPTION
## Sensitive Credential Checks

- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

Added capability of Streaming File from Azure Blob storage to AWS S3 bucket

## Description

Implement streaming file transfer in `GRPCFileClient` and chunk assembly in `FileChunkAssembler`.
Validate destination path and use Redis offset in `ClientGRPCFileExchangeJob`.
Add streaming-aware upload behavior to `S3ReceivedFileStorage`.
Update unit tests for `GRPCFileClient` and `S3ReceivedFileStorage`.

Closes `DPAV-1868`

## How Has This Been Tested?

Yes

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

