### PR TITLE
DPAV-2306-added-workload-identity-service-5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,6 +370,12 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.azure</groupId>
+          <artifactId>azure-core-http-netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/src/main/java/uk/gov/dbt/ndtp/federator/common/storage/provider/file/client/AzureBlobClientFactory.java
+++ b/src/main/java/uk/gov/dbt/ndtp/federator/common/storage/provider/file/client/AzureBlobClientFactory.java
@@ -58,10 +58,12 @@ public final class AzureBlobClientFactory {
         }
 
         try {
-            // Use System-Assigned Workload Identity only
-            WorkloadIdentityCredential credential = new WorkloadIdentityCredentialBuilder().build();
+            // Use AKS Workload Identity  only
+            WorkloadIdentityCredential credential = new WorkloadIdentityCredentialBuilder()
+                    .httpClient(httpClient)
+                    .build();
             log.info(
-                    "Azure BlobServiceClient initialized for endpoint: {} using System Workload Identity using okhttp",
+                    "Azure BlobServiceClient initialized for endpoint: {} using AKS Workload Identity (okhttp)",
                     endpoint);
             return new BlobServiceClientBuilder()
                     .endpoint(endpoint)

--- a/src/test/java/uk/gov/dbt/ndtp/federator/common/storage/provider/file/client/AzureBlobClientFactoryTest.java
+++ b/src/test/java/uk/gov/dbt/ndtp/federator/common/storage/provider/file/client/AzureBlobClientFactoryTest.java
@@ -111,6 +111,7 @@ class AzureBlobClientFactoryTest {
 
         try (MockedConstruction<WorkloadIdentityCredentialBuilder> mockedCredBuilder =
                         mockConstruction(WorkloadIdentityCredentialBuilder.class, (mock, context) -> {
+                            when(mock.httpClient(any(HttpClient.class))).thenReturn(mock);
                             when(mock.build()).thenReturn(mock(WorkloadIdentityCredential.class));
                         });
                 MockedConstruction<BlobServiceClientBuilder> mockedBuilder =


### PR DESCRIPTION
## Sensitive Credential Checks

- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

Removed Netty altogether from Azure dependency and now Identity is also using okhttp

## Description

- Removed Netty altogether from Azure dependency and now Identity is also using okhttp

## How Has This Been Tested?
No

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

