### PR TITLE
feat(dpav-2610): hardened the federator client and server docker images

### DIFF
--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -25,20 +25,23 @@ FROM eclipse-temurin:21 AS federator
 
 LABEL org.opencontainers.image.source=https://github.com/National-Digital-Twin/federator
 
-RUN mkdir -p /library/ /app/
-RUN useradd -Mg root federator-service
-RUN chown federator-service /library/ /app/
+RUN mkdir -p /library/ /app/ && \
+	groupadd appgroup && \
+	useradd -Mg appgroup federator-service && \
+	chown -R :appgroup /library/ /app/
 WORKDIR /app
-USER federator-service
 ARG JAR_NAME
 COPY target/${JAR_NAME}.jar /app/app.jar
+USER federator-service
 ENTRYPOINT java -cp /app/app.jar:/library/* $PROPERTIES uk.gov.dbt.ndtp.federator.FederatorClient $ARGS
 
 # Federation Client with MSK auth support
 FROM federator AS federator-msk
 USER root
-RUN mkdir -p /baked-library/
-RUN chown federator-service /baked-library/
+RUN mkdir -p /baked-library/ && \
+	groupadd appgroup && \
+	useradd -Mg appgroup federator-service && \
+	chown -R :appgroup /baked-library/
 ARG MSK_VERSION=2.3.0
 ADD --chmod=644 https://github.com/aws/aws-msk-iam-auth/releases/download/v${MSK_VERSION}/aws-msk-iam-auth-${MSK_VERSION}-all.jar /baked-library/
 USER federator-service

--- a/docker/Dockerfile.gh-actions
+++ b/docker/Dockerfile.gh-actions
@@ -30,9 +30,10 @@ RUN apt-get update && \
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID=federator
 
-RUN mkdir -p /app/ /app/lib/ /app/agents/ /opt/ianode/sbom/
-RUN useradd -Mg root ianode-service
-RUN chown ianode-service /app/ /app/lib/ /app/agents/ /opt/ianode/sbom/
+RUN mkdir -p /app/ /app/lib/ /app/agents/ /opt/ianode/sbom/ && \
+    groupadd appgroup && \
+    useradd -Mg appgroup ianode-service && \
+    chown -R :appgroup /app/ /app/lib/ /app/agents/ /opt/ianode/sbom/
 WORKDIR /app
 USER ianode-service
 ENV PROJECT_VERSION=${PROJECT_VERSION}

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -25,20 +25,23 @@ FROM eclipse-temurin:21 AS federator
 
 LABEL org.opencontainers.image.source=https://github.com/National-Digital-Twin/federator
 
-RUN mkdir -p /library/ /app/
-RUN useradd -Mg root federator-service
-RUN chown federator-service /library/ /app/
+RUN mkdir -p /library/ /app/ && \
+	groupadd appgroup && \
+	useradd -Mg appgroup federator-service && \
+	chown -R :appgroup /library/ /app/
 WORKDIR /app
-USER federator-service
 ARG JAR_NAME
 COPY target/${JAR_NAME}.jar /app/app.jar
+USER federator-service
 ENTRYPOINT java -cp /app/app.jar:/library/* $PROPERTIES uk.gov.dbt.ndtp.federator.FederatorServer $ARGS
 
 # Federation Server with MSK auth support
 FROM federator AS federator-msk
 USER root
-RUN mkdir -p /baked-library/
-RUN chown federator-service /baked-library/
+RUN mkdir -p /baked-library/ && \
+	groupadd appgroup && \
+	useradd -Mg appgroup federator-service && \
+	chown -R :appgroup /baked-library/
 ARG MSK_VERSION=2.3.0
 ADD --chmod=644 https://github.com/aws/aws-msk-iam-auth/releases/download/v${MSK_VERSION}/aws-msk-iam-auth-${MSK_VERSION}-all.jar /baked-library/
 USER federator-service


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[DPAV-2610](https://ndtp.atlassian.net/browse/DPAV-2610)

## Description

- Added a custom group for the federator user
- Replaced root with the custom group for the federator user
- Gave permissions to the custom group to the folders required to run the container

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

Tested locally and is working as expected

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

