### PR TITLE
fix(ci): skip SonarQube scan for dependabot-triggered PRs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -57,10 +57,15 @@ jobs:
       - name: Code Coverage
         env:
           GH_PACKAGES_PAT: ${{ secrets.GH_PACKAGES_PAT }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_N3 }}
-        run: ./mvnw $MAVEN_CLI_OPTS verify -Dsonar.projectKey=National-Node-Net_federator -Dsonar.organization=national-node-net -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: ./mvnw $MAVEN_CLI_OPTS verify
       - name: Verify JaCoCo XML exists
         run: ls -l target/site/jacoco/jacoco.xml
+      - name: SonarQube Scan
+        if: github.actor != 'dependabot[bot]'
+        env:
+          GH_PACKAGES_PAT: ${{ secrets.GH_PACKAGES_PAT }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_N3 }}
+        run: ./mvnw $MAVEN_CLI_OPTS org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=National-Node-Net_federator -Dsonar.organization=national-node-net -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
   lint:
     permissions:
       contents: read


### PR DESCRIPTION
GitHub does not pass repository/org secrets to workflow runs triggered by a Dependabot-authored pull_request event. Since the SonarQube scan step used `SONAR_TOKEN_N3`, it always failed with "Not authorized or project not found" on Dependabot PRs. This splits the Code Coverage step (which still always runs `mvn verify` to produce the JaCoCo report) from the SonarQube scan step, and guards the scan step with `if: github.actor != 'dependabot[bot]'` so it is skipped (not failed) for Dependabot PRs, matching the pattern already used in National-Digital-Twin/ospo-resources' ci.yml.