### PR TITLE
fix(ci): skip SonarQube scan for dependabot-triggered PRs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -54,10 +54,6 @@ jobs:
         env:
           GH_PACKAGES_PAT: ${{ secrets.GH_PACKAGES_PAT }}
         run: ./mvnw $MAVEN_CLI_OPTS verify
-      - name: Code Coverage
-        env:
-          GH_PACKAGES_PAT: ${{ secrets.GH_PACKAGES_PAT }}
-        run: ./mvnw $MAVEN_CLI_OPTS verify
       - name: Verify JaCoCo XML exists
         run: ls -l target/site/jacoco/jacoco.xml
       - name: SonarQube Scan

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -57,10 +57,15 @@ jobs:
       - name: Code Coverage
         env:
           GH_PACKAGES_PAT: ${{ secrets.GH_PACKAGES_PAT }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_N3 }}
-        run: ./mvnw $MAVEN_CLI_OPTS verify -Dsonar.projectKey=National-Node-Net_federator -Dsonar.organization=national-node-net -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: ./mvnw $MAVEN_CLI_OPTS verify
       - name: Verify JaCoCo XML exists
         run: ls -l target/site/jacoco/jacoco.xml
+      - name: SonarQube Scan
+        if: github.actor != 'dependabot[bot]'
+        env:
+          GH_PACKAGES_PAT: ${{ secrets.GH_PACKAGES_PAT }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_N3 }}
+        run: ./mvnw $MAVEN_CLI_OPTS org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=National-Node-Net_federator -Dsonar.organization=national-node-net -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
   lint:
     permissions:
       contents: read


### PR DESCRIPTION
Dependabot PRs don't get access to repo secrets, so the SonarQube scan step was failing every time trying to use `SONAR_TOKEN_N3`. This skips the scan step for Dependabot PRs.